### PR TITLE
Fix up url clauses for CSS files in sub-directories

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -31,6 +31,8 @@ var HitchCompiler = (function(){
 			pluginSources = [],
 			// collection of constants defined
 			constants = [],
+                        // pathname part of href
+                        path = '',
 			invokeFinished = function(outModel){
 				outModel.originNode = originNode;
 				finished(outModel);
@@ -243,6 +245,12 @@ var HitchCompiler = (function(){
 			return temp;
 		};
 			
+                // Set path to relative location of css file where applicable
+                if (originNode.href) {
+                  path = originNode.getAttribute("href");
+                  path = path.substring(0, path.lastIndexOf('/'));
+                }
+
 		// Process source rules for plugins to require
 		src = src.replace(/\@-hitch-requires[^\;]*\;/g, function(m,i,s){
 			var parts = m.split(/\s|\;/g);
@@ -369,6 +377,9 @@ var HitchCompiler = (function(){
 					
 					// normalize rule again
 					raw = raw + " }";
+
+                                        // transform any urls except data urls
+                                        raw = raw.replace(/url\((["'])(?!data:)/, "url($1" + path + "/");
 					
 					// placeholder raw rule for use later
 					nativeRule = raw;

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -378,8 +378,8 @@ var HitchCompiler = (function(){
 					// normalize rule again
 					raw = raw + " }";
 
-                                        // transform any urls except data urls
-                                        raw = raw.replace(/url\((["'])(?!data:)/, "url($1" + path + "/");
+                                        // transform any relative urls 
+                                        raw = raw.replace(/url\((["'])(?!\w*:|\/)/, "url($1" + path + "/");
 					
 					// placeholder raw rule for use later
 					nativeRule = raw;


### PR DESCRIPTION
Hi,

This is a fix for an issue I encountered where the CSS file is in a sub-directory relative to the html file that references it e.g. 

``` html
    <link rel="stylesheet" href="styles/main.css" data-hitch-interpret>
```

and the css file itself contains e.g. a background property with a url parameter such as:

``` css
    background: url("icons.png") no-repeat;
```

The problem is, when Hitch picks up the css file and translates it into an embedded &lt;style&gt; section, it needs to fix up the _url_ parameter - in this case it needs to change it to _styles/icons.png_
